### PR TITLE
Prove ownership for google-search

### DIFF
--- a/static/googled34c7bbe6f1836c5.html
+++ b/static/googled34c7bbe6f1836c5.html
@@ -1,0 +1,1 @@
+google-site-verification: googled34c7bbe6f1836c5.html


### PR DESCRIPTION
This PR adds HTML that will be used by Google Search as proof of URL ownership, so it can index and use the docs as a data source (needed for Agent Builder)