### PR TITLE
Add RxInferBenchmarks.jl dashboard reference

### DIFF
--- a/app/components/NavBar.tsx
+++ b/app/components/NavBar.tsx
@@ -7,6 +7,7 @@ import {
     BookOpenText, // Documentation
     NotebookPen, // Get Started
     Code2, // Examples
+    Gauge, // Benchmarks
     MessageCircle, // Discussions
     Users, // Team
     Github, // GitHub
@@ -50,6 +51,11 @@ const navItems: NavItem[] = [
         label: 'Examples',
         href: 'https://examples.rxinfer.com',
         icon: Code2
+    },
+    {
+        label: 'Benchmarks',
+        href: 'https://benchmarks.rxinfer.com',
+        icon: Gauge
     },
     {
         label: 'Discussions',

--- a/app/components/RxInferIsFast.tsx
+++ b/app/components/RxInferIsFast.tsx
@@ -135,6 +135,13 @@ export default function RxInferIsFast() {
                         >
                             View benchmark details
                         </Link>
+                        <Link
+                            href="https://benchmarks.rxinfer.com"
+                            target="_blank"
+                            className="text-sm font-medium border border-gray-200 hover:border-blue-300 text-gray-400 hover:text-blue-800 flex items-center gap-2 px-3 py-1 rounded-full hover:bg-blue-100 transition-colors duration-200"
+                        >
+                            View live benchmarks dashboard
+                        </Link>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

Adds a reference to [RxInferBenchmarks.jl](https://github.com/ReactiveBayes/RxInferBenchmarks.jl) — the live dashboard of RxInfer performance metrics over time — in two places on the site. Both links point to **https://benchmarks.rxinfer.com**.

## Changes

- **Header nav** (`app/components/NavBar.tsx`): new **"Benchmarks"** item with a `Gauge` icon, placed after "Examples". Renders in both desktop and mobile menus.
- **"RxInfer is Fast" section** (`app/components/RxInferIsFast.tsx`): new **"View live benchmarks dashboard"** pill link next to the existing "View benchmark details" link, styled identically.

## Verification

- `npm run build` passes — static export compiles with no TypeScript/lint errors.

> Note: links target the custom domain `benchmarks.rxinfer.com`. The dashboard currently deploys to `reactivebayes.github.io/RxInferBenchmarks.jl/`, so the custom domain/CNAME needs to be configured for the links to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)